### PR TITLE
終日予定に対応

### DIFF
--- a/imananishiton.gs
+++ b/imananishiton.gs
@@ -22,7 +22,7 @@ Imananishiton.prototype = {
     var calendar = CalendarApp.getCalendarById(this.email)
     var events = calendar.getEvents(start, end)
     return events.filter(function(event) {
-      return !(event.isAllDayEvent())
+      return !event.isAllDayEvent()
     })
   },
   createStatusMessage: function(event) {

--- a/imananishiton.gs
+++ b/imananishiton.gs
@@ -46,7 +46,11 @@ Imananishiton.prototype = {
     }
     var message = 'カレンダー予定：' + event.getTitle()
     if (event.getLocation() !== '') {
-      message += ' @ ' + event.getLocation().substr(0, 20)
+      if (event.getLocation().length > 20) {
+        message += ' @ ' + event.getLocation().substr(0, 20) + '...'
+      } else {
+        message += ' @ ' + event.getLocation()
+      }
     }
     if (event.isAllDayEvent()) {
       return message + '【終日】'

--- a/imananishiton.gs
+++ b/imananishiton.gs
@@ -32,7 +32,7 @@ Imananishiton.prototype = {
     var schedule = this.getEventSchedule(event)
     var message = 'カレンダー予定：' + event.getTitle()
     if (event.getLocation() !== '') {
-      message += ' @ ' + event.getLocation()
+      message += ' @ ' + event.getLocation().substr(0, 20)
     }
     return message + '【' + schedule['start'] + ' ～ ' + schedule['end'] + '】'
   },

--- a/imananishiton.gs
+++ b/imananishiton.gs
@@ -24,21 +24,10 @@ Imananishiton.prototype = {
     return events.sort(this.compareSchedule)
   },
   compareSchedule: function(first, second) {
-    if (!first.isAllDayEvent() && !second.isAllDayEvent()) {
-      if (first.getStartTime() < second.getStartTime()) {
-        return 1
-      } else if (first.getStartTime() > second.getStartTime()) {
-        return -1
-      } else {
-        return 0
-      }
-    }
-    if (!first.isAllDayEvent()) {
-      return -1
-    }
-    if (!second.isAllDayEvent()) {
-      return 1
-    }
+    if ((first.isAllDayEvent() && second.isAllDayEvent()) || first.getStartTime() === second.getStartTime()) { return 0 }
+    if (second.isAllDayEvent()) { return -1 }
+    if (first.isAllDayEvent()) { return 1 }
+    return first.getStartTime() < second.getStartTime() ? 1 : -1
   },
   createStatusMessage: function(event) {
     if (!event || this.isPrivateEvent(event)) {

--- a/imananishiton.gs
+++ b/imananishiton.gs
@@ -20,7 +20,10 @@ Imananishiton.prototype = {
     var start = new Date()
     var end = new Date(start.getTime() + 60 * 1000)
     var calendar = CalendarApp.getCalendarById(this.email)
-    return calendar.getEvents(start, end)
+    var events = calendar.getEvents(start, end)
+    return events.filter(function(event) {
+      return !(event.isAllDayEvent())
+    })
   },
   createStatusMessage: function(event) {
     if (!event || this.isPrivateEvent(event)) {

--- a/imananishiton.gs
+++ b/imananishiton.gs
@@ -21,19 +21,37 @@ Imananishiton.prototype = {
     var end = new Date(start.getTime() + 60 * 1000)
     var calendar = CalendarApp.getCalendarById(this.email)
     var events = calendar.getEvents(start, end)
-    return events.filter(function(event) {
-      return !event.isAllDayEvent()
-    })
+    return events.sort(this.compareSchedule)
+  },
+  compareSchedule: function(first, second) {
+    if (!first.isAllDayEvent() && !second.isAllDayEvent()) {
+      if (first.getStartTime() < second.getStartTime()) {
+        return 1
+      } else if (first.getStartTime() > second.getStartTime()) {
+        return -1
+      } else {
+        return 0
+      }
+    }
+    if (!first.isAllDayEvent()) {
+      return -1
+    }
+    if (!second.isAllDayEvent()) {
+      return 1
+    }
   },
   createStatusMessage: function(event) {
     if (!event || this.isPrivateEvent(event)) {
       return 'カレンダー予定：予定なし'
     }
-    var schedule = this.getEventSchedule(event)
     var message = 'カレンダー予定：' + event.getTitle()
     if (event.getLocation() !== '') {
       message += ' @ ' + event.getLocation().substr(0, 20)
     }
+    if (event.isAllDayEvent()) {
+      return message + '【終日】'
+    }
+    var schedule = this.getEventSchedule(event)
     return message + '【' + schedule['start'] + ' ～ ' + schedule['end'] + '】'
   },
   isPrivateEvent: function(event) {


### PR DESCRIPTION
#3

以下の2つの対応をしました。

- 終日予定のスケジュールはstatusに反映しない
- スケジュールの会場が多数登録されていた場合slack statusのmessageの100文字制限を超えてしまうため、20文字程度でトリミングする

> status_text - a string of no more than 100 characters; does not support markup or other formatting, like user mentions. May contain :emoji: references.

https://api.slack.com/docs/presence-and-status